### PR TITLE
Add date range overview, PDF export, configurable export columns, and security hardening

### DIFF
--- a/resources/js/Pages/ImportExport/Index.vue
+++ b/resources/js/Pages/ImportExport/Index.vue
@@ -109,6 +109,21 @@ const submitPdf = () => {
                 }}
             </p>
             <div class="mt-4 space-y-3">
+
+                <div class="flex gap-4">
+                    <Button class="flex-1" variant="outline" @click="submitCsv" :disabled="form.processing">
+                        <FileType />
+                        {{ $t('app.export as csv file') }}
+                    </Button>
+                    <Button class="flex-1" variant="outline" @click="submitExcel" :disabled="form.processing">
+                        <FileChartPie />
+                        {{ $t('app.export as excel file') }}
+                    </Button>
+                    <Button class="flex-1" variant="outline" @click="submitPdf" :disabled="form.processing">
+                        <FileText />
+                        {{ $t('app.export as pdf file') }}
+                    </Button>
+                </div>
                 <div class="flex flex-wrap items-end gap-4">
                     <div class="flex flex-col gap-2">
                         <span class="text-sm leading-none font-medium">{{ $t('app.select the time period you want to export.') }}</span>
@@ -148,20 +163,6 @@ const submitPdf = () => {
                             </SelectContent>
                         </Select>
                     </div>
-                </div>
-                <div class="flex gap-4">
-                    <Button class="flex-1" variant="outline" @click="submitCsv" :disabled="form.processing">
-                        <FileType />
-                        {{ $t('app.export as csv file') }}
-                    </Button>
-                    <Button class="flex-1" variant="outline" @click="submitExcel" :disabled="form.processing">
-                        <FileChartPie />
-                        {{ $t('app.export as excel file') }}
-                    </Button>
-                    <Button class="flex-1" variant="outline" @click="submitPdf" :disabled="form.processing">
-                        <FileText />
-                        {{ $t('app.export as pdf file') }}
-                    </Button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Add date range overview, PDF export, configurable export columns, and security hardening

### Summary

- **Date range overview** — New `RangeController` and `Overview/Range/Show` view allow users to view work/break/overtime data across any custom date range, with per-day drill-down links. Route parameters `{start}` and `{end}` are constrained to `YYYY-MM-DD` via regex patterns in `AppServiceProvider` and resolved to `Carbon` instances through dedicated route bindings.
- **PDF export** — New `PdfController` and `ExportService::exportAsPdf()` using `spatie/laravel-pdf` (backed by `dompdf/dompdf`) generate a formatted export document. Paper size and orientation are configurable per user. `LARAVEL_PDF_DRIVER=dompdf` added to `.env.example`.
- **Configurable export columns** — All three export formats (CSV, Excel, PDF) now respect per-column visibility toggles managed through the new `ExportSettings` spatie-settings class. A dedicated `Settings/ExportController`, `UpdateExportSettingsRequest` (with strict validation), and `Settings/Export/Edit` view are introduced, with a new settings route group.
- **Date range and project filtering for exports** — All export controllers now accept optional `start_date`, `end_date`, and `project_id` request parameters, passed through to `ExportService`. The `ImportExportController` passes the project list to the view to power the project filter UI.
- **Danish locale** — `da_DK` added to `LocaleService::LOCALE_MAPPING` and Danish translations added for validation and region fields.
- **Security hardening** — Replaced unescaped string interpolation in `shell_exec` calls with `escapeshellarg()` across `CsvController`, `ExcelController`, `PdfController`, and the `open` route, preventing command injection via crafted file paths or URL parameters.

### Test plan

- [ ] Navigate to Overview → Date Range; verify the chart renders correctly for a custom start/end date, bars are clickable to the day view, and reversed dates are auto-corrected
- [ ] Export as CSV/Excel/PDF with no filters; confirm all columns appear and the export file opens correctly
- [ ] Export with a date range and project filter applied; confirm only matching timestamps appear in the export
- [ ] Toggle individual column visibility in Settings → Export and re-export; confirm toggled columns are absent from the file headers and rows
- [ ] Change PDF paper size and orientation in Settings → Export; confirm the generated PDF reflects the chosen settings
- [ ] Verify `escapeshellarg` hardening: attempt a save path containing `"` or `;` characters and confirm no shell injection occurs and the folder still opens correctly on both macOS and Windows
- [ ] Verify the `open` route rejects (or safely handles) a `url` parameter containing shell metacharacters
