### PR TITLE
fix: harden NativePHP packaged startup configuration

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 
 use Illuminate\Support\Str;
 
+$mysqlSslCaOption = null;
+
+if (defined('Pdo\\Mysql::ATTR_SSL_CA')) {
+    $mysqlSslCaOption = constant('Pdo\\Mysql::ATTR_SSL_CA');
+} elseif (defined('PDO::MYSQL_ATTR_SSL_CA')) {
+    $mysqlSslCaOption = constant('PDO::MYSQL_ATTR_SSL_CA');
+}
+
 return [
 
     /*
@@ -63,8 +71,8 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            'options' => extension_loaded('pdo_mysql') && $mysqlSslCaOption !== null ? array_filter([
+                $mysqlSslCaOption => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 
@@ -83,8 +91,8 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            'options' => extension_loaded('pdo_mysql') && $mysqlSslCaOption !== null ? array_filter([
+                $mysqlSslCaOption => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 

--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -103,7 +103,7 @@ return [
          * The updater provider to use.
          * Supported: "github", "s3", "spaces"
          */
-        'default' => env('NATIVEPHP_UPDATER_PROVIDER', 'spaces'),
+        'default' => trim((string) env('NATIVEPHP_UPDATER_PROVIDER', '')) ?: 'spaces',
 
         'providers' => [
             'github' => [


### PR DESCRIPTION
Tried building and installing TimeScribe locally on macOS and found packaged startup failures.

  Issue:

  - Packaged app could fail during Laravel bootstrap when PDO::MYSQL_ATTR_SSL_CA was unavailable in the bundled PHP runtime.
  - Empty NATIVEPHP_UPDATER_PROVIDER could resolve to an invalid updater provider.

  Fix:

  - Added a safe fallback for MySQL SSL CA constant detection in config/database.php.
  - Treated empty NATIVEPHP_UPDATER_PROVIDER as unset and fallback to spaces in config/nativephp.php.

  Result:

  - Packaged macOS builds boot Laravel reliably and the tray/window UI loads as expected.