### PR TITLE
feat: codex natural-language time logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,20 @@ php artisan native:build mac
 php artisan native:build win
 ```
 
+### Natural Language Time Logging (Developers / Codex)
+
+You can log work/break time by describing it in plain English:
+
+```bash
+php artisan timescribe:log "yesterday worked on Acme from 09:00 to 11:00"
+php artisan timescribe:log "2026-02-20 break from 09:00 to 09:30"
+php artisan timescribe:log "yesterday worked on \"New Project\" for 2h" --create-project
+php artisan timescribe:log "yesterday for 90m" --project="Acme"
+php artisan timescribe:log "yesterday worked on Acme for 2h" --dry-run
+```
+
+If the new range overlaps existing timestamps, TimeScribe shows the overlaps and asks for confirmation before trimming/splitting existing entries. Use `--force-overwrite` to skip the confirmation, or `--carve` for explicit overwrite mode.
+
 ## 🖼 Screenshots
 
 ### 🧭 Menu Bar

--- a/app/Console/Commands/LogTime.php
+++ b/app/Console/Commands/LogTime.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Enums\TimestampTypeEnum;
+use App\Models\Project;
+use App\Models\Timestamp;
+use App\Services\LocaleService;
+use App\Services\NaturalLanguage\TimeLogTextParser;
+use App\Services\TimestampService;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+
+class LogTime extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'timescribe:log
+        {text : Natural language description (e.g. "yesterday worked on Acme from 09:00 to 11:00")}
+        {--project= : Project name (preferred when unsure)}
+        {--type= : work|break (overrides detection)}
+        {--date= : Date override (YYYY-MM-DD)}
+        {--start= : Start time override (e.g. 09:00, 9am)}
+        {--end= : End time override (e.g. 11:30)}
+        {--duration= : Duration override (e.g. 2h, 90m, 1h30m)}
+        {--create-project : Create the project if it does not exist}
+        {--source=Codex : Value for timestamps.source}
+        {--carve : Allow trimming/splitting existing timestamps if overlapping}
+        {--force-overwrite : Overwrite overlaps without asking}
+        {--dry-run : Print parsed result without writing}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Log a work/break timestamp from natural language';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        new LocaleService;
+
+        $text = (string) $this->argument('text');
+
+        $typeOption = $this->option('type');
+        $type = filled($typeOption)
+            ? TimestampTypeEnum::tryFrom((string) $typeOption)
+            : null;
+
+        if (filled($typeOption) && ! $type instanceof TimestampTypeEnum) {
+            $this->error('Invalid --type. Use "work" or "break".');
+
+            return self::FAILURE;
+        }
+
+        $parser = new TimeLogTextParser;
+        $parsed = $parser->parse(
+            text: $text,
+            now: now(),
+            typeOverride: $type,
+            dateOverride: $this->option('date') ? (string) $this->option('date') : null,
+            startOverride: $this->option('start') ? (string) $this->option('start') : null,
+            endOverride: $this->option('end') ? (string) $this->option('end') : null,
+            durationOverride: $this->option('duration') ? (string) $this->option('duration') : null,
+        );
+
+        if ($parsed['error']) {
+            $this->error($parsed['error']);
+
+            return self::FAILURE;
+        }
+
+        /** @var Carbon $startAt */
+        $startAt = $parsed['start_at'];
+        /** @var Carbon $endAt */
+        $endAt = $parsed['end_at'];
+        /** @var TimestampTypeEnum $resolvedType */
+        $resolvedType = $parsed['type'];
+
+        if ($parsed['guessed_start_at'] && $parsed['duration_seconds']) {
+            $dayStart = $parsed['date']->copy()->startOfDay();
+            $dayEnd = $parsed['date']->copy()->endOfDay();
+
+            $last = Timestamp::where('started_at', '>=', $dayStart)
+                ->where('started_at', '<=', $dayEnd)
+                ->orderByRaw('COALESCE(ended_at, last_ping_at, started_at) DESC')
+                ->first();
+
+            if ($last) {
+                $lastEnd = $last->ended_at ?? $last->last_ping_at ?? $last->started_at;
+                $startAt = $lastEnd->copy();
+                $endAt = $startAt->copy()->addSeconds((int) $parsed['duration_seconds']);
+            }
+        }
+
+        if (! $startAt->isSameDay($endAt)) {
+            $this->error('Cross-midnight ranges are not supported. Split into two logs.');
+
+            return self::FAILURE;
+        }
+
+        if ($startAt->isAfter(now()) || $endAt->isAfter(now())) {
+            $this->error('Start and end must be in the past.');
+
+            return self::FAILURE;
+        }
+
+        $projectNameOption = $this->option('project') ? (string) $this->option('project') : null;
+        $project = $this->resolveProject($projectNameOption, $text);
+
+        if (! $project instanceof Project && filled($projectNameOption) && $this->option('create-project')) {
+            $project = Project::create(['name' => $projectNameOption]);
+        }
+
+        if (! $project instanceof Project && $this->option('create-project')) {
+            $candidate = $parsed['project_candidate'];
+            if (filled($candidate)) {
+                $project = Project::create(['name' => $candidate]);
+            }
+        }
+
+        $projectId = $project?->id;
+        $source = (string) $this->option('source');
+
+        if ($this->option('dry-run')) {
+            $this->line('Parsed:');
+            $this->line('  Type: '.$resolvedType->value);
+            $this->line('  Project: '.($project?->name ?? '(none)'));
+            $this->line('  Start: '.$startAt->toDateTimeString());
+            $this->line('  End: '.$endAt->toDateTimeString());
+            $this->line('  Source: '.$source);
+
+            return self::SUCCESS;
+        }
+
+        $carve = (bool) $this->option('carve');
+        $forceOverwrite = (bool) $this->option('force-overwrite');
+        $overlappingTimestamps = $this->getOverlappingTimestamps($startAt, $endAt);
+
+        if ($overlappingTimestamps->isNotEmpty()) {
+            $this->warn('Overlapping timestamps found:');
+            $this->table(
+                ['ID', 'Type', 'Project', 'Start', 'End', 'Source', 'Description'],
+                $this->buildOverlapRows($overlappingTimestamps)
+            );
+
+            if (! $carve && ! $forceOverwrite) {
+                if (! $this->input->isInteractive()) {
+                    $this->error('Time range overlaps existing timestamps. Re-run with --carve or --force-overwrite.');
+
+                    return self::FAILURE;
+                }
+
+                $carve = $this->confirm(
+                    'Overwrite by trimming/splitting these existing timestamps?',
+                    true
+                );
+                if (! $carve) {
+                    $this->info('Canceled. No changes were made.');
+
+                    return self::FAILURE;
+                }
+            } else {
+                $carve = true;
+            }
+        }
+
+        if ($carve) {
+            TimestampService::create($startAt, $endAt, $resolvedType, $parsed['description'], $projectId);
+
+            Timestamp::where('started_at', $startAt)
+                ->where('ended_at', $endAt)
+                ->where('type', $resolvedType)
+                ->latest('id')
+                ->first()?->update(['source' => $source]);
+        } else {
+            Timestamp::create([
+                'type' => $resolvedType,
+                'project_id' => $projectId,
+                'started_at' => $startAt,
+                'ended_at' => $endAt,
+                'last_ping_at' => $endAt,
+                'description' => $parsed['description'],
+                'source' => $source,
+            ]);
+        }
+
+        $this->info('Logged time successfully.');
+
+        return self::SUCCESS;
+    }
+
+    private function resolveProject(?string $projectOption, string $text): ?Project
+    {
+        if (filled($projectOption)) {
+            return Project::withTrashed()->where('name', $projectOption)->first();
+        }
+
+        $projects = Project::withTrashed()->get(['id', 'name']);
+        $haystack = mb_strtolower($text);
+
+        $best = null;
+        foreach ($projects as $project) {
+            $needle = mb_strtolower($project->name);
+            if ($needle !== '' && str_contains($haystack, $needle)) {
+                if (! $best || mb_strlen($project->name) > mb_strlen($best->name)) {
+                    $best = $project;
+                }
+            }
+        }
+
+        return $best;
+    }
+
+    private function getOverlappingTimestamps(Carbon $startAt, Carbon $endAt): EloquentCollection
+    {
+        return Timestamp::where('started_at', '<', $endAt)
+            ->where(function ($query) use ($startAt): void {
+                $query->whereNull('ended_at')
+                    ->orWhere('ended_at', '>', $startAt);
+            })
+            ->with('project:id,name')
+            ->orderBy('started_at')
+            ->get();
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    private function buildOverlapRows(EloquentCollection $overlappingTimestamps): array
+    {
+        return $overlappingTimestamps->map(function (Timestamp $timestamp): array {
+            $end = $timestamp->ended_at ?? $timestamp->last_ping_at ?? $timestamp->started_at;
+            $description = trim((string) ($timestamp->description ?? ''));
+            if (mb_strlen($description) > 50) {
+                $description = mb_substr($description, 0, 47).'...';
+            }
+
+            return [
+                (string) $timestamp->id,
+                $timestamp->type->value,
+                $timestamp->project?->name ?? '-',
+                $timestamp->started_at->format('Y-m-d H:i'),
+                $end->format('Y-m-d H:i'),
+                $timestamp->source ?? '-',
+                $description !== '' ? $description : '-',
+            ];
+        })->all();
+    }
+}

--- a/app/Services/LocaleService.php
+++ b/app/Services/LocaleService.php
@@ -40,8 +40,16 @@ class LocaleService
     {
         if (! $this->settings->timezone) {
             $this->settings->timezone = config('app.timezone');
-            $systemTimezone = System::timezone();
-            if (in_array($systemTimezone, \DateTimeZone::listIdentifiers())) {
+            $systemTimezone = null;
+            if (! app()->runningUnitTests()) {
+                try {
+                    $systemTimezone = System::timezone();
+                } catch (\Throwable) {
+                    $systemTimezone = null;
+                }
+            }
+
+            if ($systemTimezone && in_array($systemTimezone, \DateTimeZone::listIdentifiers())) {
                 $this->settings->timezone = $systemTimezone;
             }
             $this->settings->save();
@@ -91,7 +99,7 @@ class LocaleService
     {
         if (app()->runningInConsole()) {
             // Für Console Commands, versuche die System-Locale zu ermitteln
-            $sysLocale = setlocale(LC_ALL, 0);
+            $sysLocale = setlocale(LC_ALL, '0');
             if (preg_match('/^([a-zA-Z]{2}_[A-Z]{2})/', $sysLocale, $matches)) {
                 return $matches[1];
             }

--- a/app/Services/NaturalLanguage/TimeLogTextParser.php
+++ b/app/Services/NaturalLanguage/TimeLogTextParser.php
@@ -1,0 +1,283 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\NaturalLanguage;
+
+use App\Enums\TimestampTypeEnum;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Date;
+
+class TimeLogTextParser
+{
+    /**
+     * @return array{
+     *   error: ?string,
+     *   type: TimestampTypeEnum,
+     *   date: ?Carbon,
+     *   start_at: ?Carbon,
+     *   end_at: ?Carbon,
+     *   duration_seconds: ?int,
+     *   guessed_start_at: bool,
+     *   description: string,
+     *   project_candidate: ?string
+     * }
+     */
+    public function parse(
+        string $text,
+        Carbon $now,
+        ?TimestampTypeEnum $typeOverride = null,
+        ?string $dateOverride = null,
+        ?string $startOverride = null,
+        ?string $endOverride = null,
+        ?string $durationOverride = null,
+    ): array {
+        $description = trim(preg_replace('/\s+/', ' ', $text) ?? $text);
+
+        $type = $typeOverride ?? $this->detectType($description);
+
+        $date = $this->detectDate($description, $now, $dateOverride);
+        if (! $date instanceof Carbon) {
+            return [
+                'error' => 'Unable to determine a date. Try adding "yesterday" or use --date=YYYY-MM-DD.',
+                'type' => $type,
+                'date' => null,
+                'start_at' => null,
+                'end_at' => null,
+                'duration_seconds' => null,
+                'guessed_start_at' => false,
+                'description' => $description,
+                'project_candidate' => null,
+            ];
+        }
+
+        $startTime = $startOverride ?? $this->detectStartTime($description);
+        $endTime = $endOverride ?? $this->detectEndTime($description);
+        $durationSeconds = $durationOverride ? $this->parseDurationSeconds($durationOverride) : $this->parseDurationSeconds($description);
+        $guessedStartAt = false;
+
+        if (! $startTime && ! $endTime && ! $durationSeconds) {
+            return [
+                'error' => 'Unable to determine a time range or duration. Try "from 09:00 to 11:00" or "for 2h", or use --start/--end/--duration.',
+                'type' => $type,
+                'date' => $date,
+                'start_at' => null,
+                'end_at' => null,
+                'duration_seconds' => null,
+                'guessed_start_at' => false,
+                'description' => $description,
+                'project_candidate' => $this->guessProjectCandidate($description),
+            ];
+        }
+
+        $dateString = $date->format('Y-m-d');
+
+        $startAt = $startTime ? $this->parseTimeOnDate($dateString, $startTime) : null;
+        $endAt = $endTime ? $this->parseTimeOnDate($dateString, $endTime) : null;
+
+        if (! $startAt instanceof Carbon && $endAt instanceof Carbon && $durationSeconds) {
+            $startAt = $endAt->copy()->subSeconds($durationSeconds);
+        }
+
+        if ($startAt instanceof Carbon && ! $endAt instanceof Carbon && $durationSeconds) {
+            $endAt = $startAt->copy()->addSeconds($durationSeconds);
+        }
+
+        if (! $startAt instanceof Carbon && ! $endAt instanceof Carbon && $durationSeconds) {
+            $suggestedStartAt = $date->copy()->setTime(9, 0, 0);
+            $startAt = $suggestedStartAt;
+            $endAt = $suggestedStartAt->copy()->addSeconds($durationSeconds);
+            $guessedStartAt = true;
+        }
+
+        if (! $startAt instanceof Carbon || ! $endAt instanceof Carbon) {
+            return [
+                'error' => 'Unable to compute a start/end time from the provided text/options.',
+                'type' => $type,
+                'date' => $date,
+                'start_at' => null,
+                'end_at' => null,
+                'duration_seconds' => $durationSeconds,
+                'guessed_start_at' => false,
+                'description' => $description,
+                'project_candidate' => $this->guessProjectCandidate($description),
+            ];
+        }
+
+        if ($endAt->lessThanOrEqualTo($startAt)) {
+            return [
+                'error' => 'End time must be after start time.',
+                'type' => $type,
+                'date' => $date,
+                'start_at' => null,
+                'end_at' => null,
+                'duration_seconds' => $durationSeconds,
+                'guessed_start_at' => false,
+                'description' => $description,
+                'project_candidate' => $this->guessProjectCandidate($description),
+            ];
+        }
+
+        if (! $startAt->isSameDay($endAt)) {
+            return [
+                'error' => 'Cross-midnight ranges are not supported. Split into two logs.',
+                'type' => $type,
+                'date' => $date,
+                'start_at' => null,
+                'end_at' => null,
+                'duration_seconds' => $durationSeconds,
+                'guessed_start_at' => false,
+                'description' => $description,
+                'project_candidate' => $this->guessProjectCandidate($description),
+            ];
+        }
+
+        return [
+            'error' => null,
+            'type' => $type,
+            'date' => $date,
+            'start_at' => $startAt,
+            'end_at' => $endAt,
+            'duration_seconds' => $durationSeconds,
+            'guessed_start_at' => $guessedStartAt,
+            'description' => $description,
+            'project_candidate' => $this->guessProjectCandidate($description),
+        ];
+    }
+
+    private function detectType(string $text): TimestampTypeEnum
+    {
+        $lower = mb_strtolower($text);
+
+        if (preg_match('/\b(break|lunch)\b/u', $lower) === 1) {
+            return TimestampTypeEnum::BREAK;
+        }
+
+        return TimestampTypeEnum::WORK;
+    }
+
+    private function detectDate(string $text, Carbon $now, ?string $override): ?Carbon
+    {
+        if (filled($override)) {
+            try {
+                return Date::parse($override)->startOfDay();
+            } catch (\Throwable) {
+                return null;
+            }
+        }
+
+        $lower = mb_strtolower($text);
+
+        if (str_contains($lower, 'yesterday')) {
+            return $now->copy()->subDay()->startOfDay();
+        }
+
+        if (str_contains($lower, 'today')) {
+            return $now->copy()->startOfDay();
+        }
+
+        if (str_contains($lower, 'tomorrow')) {
+            return $now->copy()->addDay()->startOfDay();
+        }
+
+        if (preg_match('/\b(\d{4}-\d{2}-\d{2})\b/u', $text, $matches) === 1) {
+            try {
+                return Date::parse($matches[1])->startOfDay();
+            } catch (\Throwable) {
+                return null;
+            }
+        }
+
+        return $now->copy()->startOfDay();
+    }
+
+    private function detectStartTime(string $text): ?string
+    {
+        if (preg_match('/\bfrom\s+([0-9]{1,2}(?::[0-9]{2})?\s*(?:am|pm)?)\b/u', $text, $matches) === 1) {
+            return trim($matches[1]);
+        }
+
+        if (preg_match('/\b([0-9]{1,2}(?::[0-9]{2})?\s*(?:am|pm)?)\s*-\s*([0-9]{1,2}(?::[0-9]{2})?\s*(?:am|pm)?)\b/u', $text, $matches) === 1) {
+            return trim($matches[1]);
+        }
+
+        if (preg_match('/\bat\s+([0-9]{1,2}(?::[0-9]{2})?\s*(?:am|pm)?)\b/u', $text, $matches) === 1) {
+            return trim($matches[1]);
+        }
+
+        return null;
+    }
+
+    private function detectEndTime(string $text): ?string
+    {
+        if (preg_match('/\bto\s+([0-9]{1,2}(?::[0-9]{2})?\s*(?:am|pm)?)\b/u', $text, $matches) === 1) {
+            return trim($matches[1]);
+        }
+
+        if (preg_match('/\b([0-9]{1,2}(?::[0-9]{2})?\s*(?:am|pm)?)\s*-\s*([0-9]{1,2}(?::[0-9]{2})?\s*(?:am|pm)?)\b/u', $text, $matches) === 1) {
+            return trim($matches[2]);
+        }
+
+        return null;
+    }
+
+    private function parseTimeOnDate(string $date, string $time): ?Carbon
+    {
+        try {
+            return Date::parse($date.' '.$time);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function parseDurationSeconds(string $text): ?int
+    {
+        $lower = mb_strtolower($text);
+
+        if (preg_match('/\bfor\s+(\d{1,2}):(\d{2})\b/u', $lower, $matches) === 1) {
+            $hours = (int) $matches[1];
+            $minutes = (int) $matches[2];
+
+            return ($hours * 3600) + ($minutes * 60);
+        }
+
+        $seconds = 0;
+        $found = false;
+
+        if (preg_match_all('/\b(\d+(?:\.\d+)?)\s*(h|hr|hrs|hour|hours)\b/u', $lower, $matches, PREG_SET_ORDER) > 0) {
+            foreach ($matches as $match) {
+                $found = true;
+                $seconds += (int) round(((float) $match[1]) * 3600);
+            }
+        }
+
+        if (preg_match_all('/\b(\d+)\s*(m|min|mins|minute|minutes)\b/u', $lower, $matches, PREG_SET_ORDER) > 0) {
+            foreach ($matches as $match) {
+                $found = true;
+                $seconds += ((int) $match[1]) * 60;
+            }
+        }
+
+        if (preg_match_all('/\b(\d+)\s*(s|sec|secs|second|seconds)\b/u', $lower, $matches, PREG_SET_ORDER) > 0) {
+            foreach ($matches as $match) {
+                $found = true;
+                $seconds += (int) $match[1];
+            }
+        }
+
+        return $found ? $seconds : null;
+    }
+
+    private function guessProjectCandidate(string $text): ?string
+    {
+        if (preg_match('/\b(?:worked on|working on|on|for)\s+\"([^\"]{2,100})\"/iu', $text, $matches) === 1) {
+            return trim($matches[1]);
+        }
+
+        if (preg_match('/\b(?:worked on|working on|on|for)\s+([A-Za-z0-9][^,.!?]{1,80}?)(?:\s+for\b|\s+from\b|\s+at\b|$)/iu', $text, $matches) === 1) {
+            return trim($matches[1]);
+        }
+
+        return null;
+    }
+}

--- a/tests/Feature/LogTimeCommandTest.php
+++ b/tests/Feature/LogTimeCommandTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Project;
+use App\Models\Timestamp;
+use Illuminate\Support\Facades\Date;
+
+it('logs a timestamp to an existing project from natural language', function (): void {
+    Date::setTestNow(Date::parse('2026-02-22 12:00:00'));
+
+    $project = Project::create(['name' => 'Acme']);
+
+    $this->artisan('timescribe:log', [
+        'text' => 'yesterday worked on Acme from 09:00 to 11:00',
+    ])->assertExitCode(0);
+
+    $timestamp = Timestamp::first();
+
+    expect($timestamp)->not->toBeNull();
+    expect($timestamp->project_id)->toBe($project->id);
+    expect($timestamp->started_at->format('Y-m-d H:i'))->toBe('2026-02-21 09:00');
+    expect($timestamp->ended_at?->format('Y-m-d H:i'))->toBe('2026-02-21 11:00');
+    expect($timestamp->source)->toBe('Codex');
+});
+
+it('can create a project via options', function (): void {
+    Date::setTestNow(Date::parse('2026-02-22 12:00:00'));
+
+    $this->artisan('timescribe:log', [
+        'text' => 'yesterday for 1h',
+        '--project' => 'New Project',
+        '--create-project' => true,
+    ])->assertExitCode(0);
+
+    expect(Project::where('name', 'New Project')->exists())->toBeTrue();
+    expect(Timestamp::count())->toBe(1);
+});
+
+it('shows overlap and overwrites after confirmation', function (): void {
+    Date::setTestNow(Date::parse('2026-02-22 12:00:00'));
+
+    Project::create(['name' => 'Acme']);
+
+    Timestamp::create([
+        'type' => 'work',
+        'started_at' => Date::parse('2026-02-21 10:00:00'),
+        'ended_at' => Date::parse('2026-02-21 12:00:00'),
+        'last_ping_at' => Date::parse('2026-02-21 12:00:00'),
+        'source' => 'Seed',
+    ]);
+
+    $this->artisan('timescribe:log', [
+        'text' => 'yesterday worked on Acme from 11:00 to 13:00',
+    ])
+        ->expectsConfirmation('Overwrite by trimming/splitting these existing timestamps?', 'yes')
+        ->assertExitCode(0);
+
+    $timestamps = Timestamp::orderBy('started_at')->get();
+
+    expect($timestamps)->toHaveCount(2);
+    expect($timestamps->get(0)->started_at->format('Y-m-d H:i'))->toBe('2026-02-21 10:00');
+    expect($timestamps->get(0)->ended_at?->format('Y-m-d H:i'))->toBe('2026-02-21 11:00');
+    expect($timestamps->get(1)->started_at->format('Y-m-d H:i'))->toBe('2026-02-21 11:00');
+    expect($timestamps->get(1)->ended_at?->format('Y-m-d H:i'))->toBe('2026-02-21 13:00');
+});
+
+it('cancels overlap overwrite when confirmation is denied', function (): void {
+    Date::setTestNow(Date::parse('2026-02-22 12:00:00'));
+
+    Project::create(['name' => 'Acme']);
+
+    Timestamp::create([
+        'type' => 'work',
+        'started_at' => Date::parse('2026-02-21 10:00:00'),
+        'ended_at' => Date::parse('2026-02-21 12:00:00'),
+        'last_ping_at' => Date::parse('2026-02-21 12:00:00'),
+        'source' => 'Seed',
+    ]);
+
+    $this->artisan('timescribe:log', [
+        'text' => 'yesterday worked on Acme from 11:00 to 13:00',
+    ])
+        ->expectsConfirmation('Overwrite by trimming/splitting these existing timestamps?', 'no')
+        ->assertExitCode(1);
+
+    expect(Timestamp::count())->toBe(1);
+    expect(Timestamp::first()?->ended_at?->format('Y-m-d H:i'))->toBe('2026-02-21 12:00');
+});

--- a/tests/Feature/TimeLogTextParserTest.php
+++ b/tests/Feature/TimeLogTextParserTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\TimestampTypeEnum;
+use App\Services\NaturalLanguage\TimeLogTextParser;
+use Illuminate\Support\Facades\Date;
+
+it('parses a duration-only log for yesterday', function (): void {
+    Date::setTestNow(Date::parse('2026-02-22 12:00:00'));
+
+    $parser = new TimeLogTextParser;
+    $result = $parser->parse('yesterday worked on Acme for 2h', now());
+
+    expect($result['error'])->toBeNull();
+    expect($result['type'])->toBe(TimestampTypeEnum::WORK);
+    expect($result['date']?->toDateString())->toBe('2026-02-21');
+    expect($result['duration_seconds'])->toBe(7200);
+    expect($result['guessed_start_at'])->toBeTrue();
+});
+
+it('parses an explicit time range', function (): void {
+    Date::setTestNow(Date::parse('2026-02-22 12:00:00'));
+
+    $parser = new TimeLogTextParser;
+    $result = $parser->parse('2026-02-20 break from 09:00 to 09:30', now());
+
+    expect($result['error'])->toBeNull();
+    expect($result['type'])->toBe(TimestampTypeEnum::BREAK);
+    expect($result['date']?->toDateString())->toBe('2026-02-20');
+    expect($result['start_at']?->format('Y-m-d H:i'))->toBe('2026-02-20 09:00');
+    expect($result['end_at']?->format('Y-m-d H:i'))->toBe('2026-02-20 09:30');
+    expect($result['guessed_start_at'])->toBeFalse();
+});


### PR DESCRIPTION
I often can’t log time immediately while working, so I need to backfill it later.

And for that I prefer to use Codex CLI / Claude Code to add it via voice-to-text.

This PR adds the code to make this work:

  - New `timescribe:log` Artisan command for natural-language time logging
  - Parsing support for common phrases (date, start/end, duration, work/break intent)
  - Project resolution from text, with optional auto-create
  - Safe overlap handling:
    - Shows existing overlapping entries
    - Asks for confirmation before overwrite
    - Uses trim/split behavior to preserve timeline continuity
    - `--force-overwrite` for non-interactive overwrite
  - `--dry-run` mode to preview parsed output
  - Feature tests for parser behavior and overlap confirmation flows
  - README section with usage examples